### PR TITLE
Feat: Provision EC2 Instance Using IaC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,25 +1,23 @@
 terraform {
   required_providers {
-    docker = {
-      source  = "kreuzwerker/docker"
-      version = "~> 3.0.1"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
     }
   }
+
+  required_version = ">= 1.2.0"
 }
 
-provider docker {}
-
-resource "docker_image" "nginx" {
-  name         = "nginx"
-  keep_locally = false
+provider "aws" {
+  region = "us-east-2"
 }
 
-resource "docker_container" "nginx" {
-  image = docker_image.nginx.image_id
-  name  = "tutorial"
+resource "aws_instance" "app_server" {
+  ami           = "ami-0030e9fc5c777545a"
+  instance_type = "t2.micro"
 
-  ports {
-    internal = 80
-    external = 8000
+  tags = {
+    Name = "ExampleAppServerInstance"
   }
 }


### PR DESCRIPTION
## What
- Use `aws` provider to connect Terraform with AWS resources.

## Why
- Basic example on how to use a provider and Terraform to provision cloud resources.